### PR TITLE
Add request middleware log level option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ $ yarn add nuxt-winston-log # or npm i nuxt-winston-log
 
       // Settings to determine if default handlers should be
       // registered for requests and errors respectively.
-      // Set to `true` to skip request logging (level: info).
+     // Set to `true` to skip request logging (level: [uses requestMiddlewareLevel]).
       skipRequestMiddlewareHandler: false,
       // Set to `true` to skip error logging (level: error).
-      skipErrorMiddlewareHandler: false
+     skipErrorMiddlewareHandler: false,
+     // Set log level for RequestMiddlewareHandler
+     requestMiddlewareLevel: 'info'
     }
     // ...
     ```

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = function WinstonLog(moduleOptions = {}) {
     useDefaultLogger: true,
     skipRequestMiddlewareHandler: false,
     skipErrorMiddlewareHandler: false,
+    requestMiddlewareLevel: 'info',
     ...this.options.winstonLog,
     ...moduleOptions,
   }
@@ -65,9 +66,7 @@ module.exports = function WinstonLog(moduleOptions = {}) {
         const isInternalNuxtRequest = reqInfo.url && reqInfo.url.includes('/_nuxt/')
 
         if (isHtmlOrJson && !isInternalNuxtRequest) {
-          logger.info(`Accessed ${req.url}`, {
-            ...reqInfo,
-          })
+          logger.log(winstonOptions.requestMiddlewareLevel, `Accessed ${req.url}`, { ...reqInfo })
         }
         next()
       })


### PR DESCRIPTION
To make an access log possible, I needed the functionality to change the log level used in the request middleware. 

It has been implemented with a new option called requestMiddlewareLevel. The middleware then uses this when logging requests.